### PR TITLE
Handle parsing gemspec with GemspecManager class

### DIFF
--- a/lib/jekyll-remote-theme.rb
+++ b/lib/jekyll-remote-theme.rb
@@ -13,11 +13,12 @@ module Jekyll
   module RemoteTheme
     class DownloadError < StandardError; end
 
-    autoload :Downloader,  "jekyll-remote-theme/downloader"
-    autoload :MockGemspec, "jekyll-remote-theme/mock_gemspec"
-    autoload :Munger,      "jekyll-remote-theme/munger"
-    autoload :Theme,       "jekyll-remote-theme/theme"
-    autoload :VERSION,     "jekyll-remote-theme/version"
+    autoload :Downloader,     "jekyll-remote-theme/downloader"
+    autoload :GemspecManager, "jekyll-remote-theme/gemspec_manager"
+    autoload :MockGemspec,    "jekyll-remote-theme/mock_gemspec"
+    autoload :Munger,         "jekyll-remote-theme/munger"
+    autoload :Theme,          "jekyll-remote-theme/theme"
+    autoload :VERSION,        "jekyll-remote-theme/version"
 
     CONFIG_KEY  = "remote_theme".freeze
     LOG_KEY     = "Remote Theme:".freeze

--- a/lib/jekyll-remote-theme/gemspec_manager.rb
+++ b/lib/jekyll-remote-theme/gemspec_manager.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module RemoteTheme
+    # Since parsing / evaluating a gemspec from third-party themes can lead to arbitrary
+    # code execution, this class exists to read the given file and handle the contents
+    # within.
+    class GemspecManager
+      SKIP_LINE_REGEX = %r!\A(?:\s*(?:#|\$|require)|\n)!
+      DEPENDENCY_MATCHER = %r!add_[runtime_]*dependency!
+      DEPENDENCY_CAPTURE_REGEX = %r!#{DEPENDENCY_MATCHER}\(?\s*(?<dependency>[^)#]+)\s*!
+      EXTRACT_QUOTED_STRING_REGEX = %r!(["'])(.*?[^\\])\1!
+
+      # Returns the trimmed contents of the provided gemspec file.
+      attr_reader :spec_contents
+
+      # Returns an array of dependencies, each entry being a sub-array containing the
+      # gem-name and its required version information.
+      attr_reader :spec_dependencies
+
+      def initialize(gemspec)
+        @gemspec = gemspec
+        @spec_contents = []
+        @spec_dependencies = []
+
+        read
+      end
+
+      # Returns the object as a debug String.
+      def inspect
+        "#<Jekyll::RemoteTheme::GemspecManager @gemspec=#{@gemspec.inspect}>"
+      end
+
+      private
+
+      # Reads the gemspec at the given path, line-by-line, ignoring lines
+      # that are comments or require a Ruby file.
+      #
+      # Returns a trimmed version of the initial gemspec file.
+      def read
+        return unless File.exist?(@gemspec)
+        File.read(@gemspec).each_line do |line|
+          next if line =~ SKIP_LINE_REGEX
+          @spec_dependencies << extract_dependency(line) if line =~ DEPENDENCY_MATCHER
+          @spec_contents << line
+        end
+      end
+
+      # Use regex to first capture required substring from current line, and then
+      # copy contents of each quoted string in the captured substring into a separate
+      # sub-array and normalizing the quotes at the same time.
+      def extract_dependency(line)
+        line.match(DEPENDENCY_CAPTURE_REGEX)["dependency"]
+          .scan(EXTRACT_QUOTED_STRING_REGEX).transpose[1]
+      end
+    end
+  end
+end

--- a/spec/fixtures/gemspecs/alldeps.gemspec
+++ b/spec/fixtures/gemspecs/alldeps.gemspec
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+lib = File.expand_path("lib", __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "alldeps/version"
+
+Gem::Specification.new do |s|
+  s.name    = "alldeps"
+  s.version = AllDeps::VERSION
+  s.authors = ["John Doe"]
+  s.summary = "Dummy gemspec"
+
+  # runtime dependencies
+  s.add_dependency "jekyll", "~> 3.5"
+  s.add_dependency "jekyll-feed", "~> 0.6"
+  s.add_dependency "jekyll-sitemap", "~> 1.5"
+
+  # development dependencies
+  s.add_dependency "bundler", "~> 1.12"
+  s.add_dependency "rake", "~> 10.0"
+end

--- a/spec/fixtures/gemspecs/braces.gemspec
+++ b/spec/fixtures/gemspecs/braces.gemspec
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+lib = File.expand_path("lib", __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "braces/version"
+
+Gem::Specification.new do |s|
+  s.name    = "braces"
+  s.version = Braces::VERSION
+  s.authors = ["John Doe"]
+  s.summary = "Dummy gemspec"
+
+  # rubocop:disable Style/StringLiterals
+  # runtime dependencies
+  s.add_dependency('jekyll',         "~> 3.5")
+  s.add_dependency('jekyll-feed',    "~> 0.6")
+  s.add_dependency('jekyll-sitemap', "~> 1.5")
+
+  # development dependencies
+  s.add_dependency('bundler',       "~> 1.12")
+  s.add_dependency('rake',          "~> 10.0")
+  # rubocop:enable Style/StringLiterals
+end

--- a/spec/fixtures/gemspecs/nodeps.gemspec
+++ b/spec/fixtures/gemspecs/nodeps.gemspec
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+lib = File.expand_path("lib", __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "nodeps/version"
+
+Gem::Specification.new do |s|
+  s.name    = "nodeps"
+  s.version = Lorem::VERSION
+  s.authors = ["John Doe"]
+  s.summary = "Dummy gemspec"
+
+  s.add_development_dependency("bundler", "~> 1.12")
+  s.add_development_dependency("rake",    "~> 10.0")
+end

--- a/spec/fixtures/gemspecs/rundev.gemspec
+++ b/spec/fixtures/gemspecs/rundev.gemspec
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+lib = File.expand_path("lib", __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "rundev/version"
+
+Gem::Specification.new do |spec|
+  spec.name    = "rundev"
+  spec.version = RunDev::VERSION
+  spec.authors = ["John Doe"]
+  spec.summary = "Dummy gemspec"
+
+  spec.add_runtime_dependency "jekyll", "~> 3.5"
+  spec.add_runtime_dependency "jekyll-feed", "~> 0.6" # some random comment
+  spec.add_runtime_dependency "jekyll-sitemap", "~> 1.5"
+
+  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "rake", "~> 10.0"
+end

--- a/spec/jekyll-remote-theme/gemspec_manager_spec.rb
+++ b/spec/jekyll-remote-theme/gemspec_manager_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe Jekyll::RemoteTheme::GemspecManager do
+  let(:dependencies) do
+    [
+      ["jekyll", "~> 3.5"],
+      ["jekyll-feed", "~> 0.6"],
+      ["jekyll-sitemap", "~> 1.5"],
+    ]
+  end
+
+  %w(alldeps braces rundev).each do |name|
+    context "with #{name}.gemspec" do
+      let(:gemspec_path) { gemspec_dir "#{name}.gemspec" }
+      subject { described_class.new(gemspec_path) }
+      let(:spec) { subject.spec_contents.join }
+
+      it "stores a trimmed version of the gemspec" do
+        expect(spec).to include("Specification.new")
+        expect(spec).to_not include("# frozen_string_literal: true")
+        expect(spec).to_not include("require \"#{name}/version\"")
+        expect(spec).to_not include("\n\n")
+      end
+
+      it "returns an array of dependencies" do
+        dependencies.each do |item|
+          expect(subject.spec_dependencies).to include(item)
+        end
+      end
+    end
+  end
+
+  context "with nodeps.gemspec" do
+    subject { described_class.new(gemspec_dir("nodeps.gemspec")) }
+
+    it "returns an empty dependency array" do
+      expect(subject.spec_dependencies).to eql([])
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,10 @@ def dest_dir
   @dest_dir ||= File.join tmp_dir, "dest"
 end
 
+def gemspec_dir(*contents)
+  File.join(fixture_path("gemspecs"), *contents)
+end
+
 def reset_tmp_dir
   FileUtils.rm_rf tmp_dir
   FileUtils.mkdir_p tmp_dir


### PR DESCRIPTION
This adds a class to handle gemspec at a given path.
  - read gemspec line-by-line and return the contents *sans* any lines that are comments and lines that purely `require` a ruby file
  - extract any specified runtime dependencies as an array of arrays. e.g. : 
    ```
    [["jekyll", "~> 3.5"], ["jekyll-feed", "~> 0.6"], ["jekyll-sitemap", "~> 1.5"]]
    ```
