### PR TITLE
Add DependencyManager class to handle theme-deps

### DIFF
--- a/lib/jekyll-remote-theme.rb
+++ b/lib/jekyll-remote-theme.rb
@@ -13,11 +13,12 @@ module Jekyll
   module RemoteTheme
     class DownloadError < StandardError; end
 
-    autoload :Downloader,  "jekyll-remote-theme/downloader"
-    autoload :MockGemspec, "jekyll-remote-theme/mock_gemspec"
-    autoload :Munger,      "jekyll-remote-theme/munger"
-    autoload :Theme,       "jekyll-remote-theme/theme"
-    autoload :VERSION,     "jekyll-remote-theme/version"
+    autoload :DependencyManager, "jekyll-remote-theme/dependency_manager"
+    autoload :Downloader,        "jekyll-remote-theme/downloader"
+    autoload :MockGemspec,       "jekyll-remote-theme/mock_gemspec"
+    autoload :Munger,            "jekyll-remote-theme/munger"
+    autoload :Theme,             "jekyll-remote-theme/theme"
+    autoload :VERSION,           "jekyll-remote-theme/version"
 
     CONFIG_KEY  = "remote_theme".freeze
     LOG_KEY     = "Remote Theme:".freeze

--- a/lib/jekyll-remote-theme/dependency_manager.rb
+++ b/lib/jekyll-remote-theme/dependency_manager.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module RemoteTheme
+    # Since evaluating a gemspec from third-party themes can lead to arbitrary code
+    # execution, this class safely reads a gemspec file at the root of given theme
+    # and handles any runtime dependencies declared within.
+    class DependencyManager
+      DEPENDENCY_MATCHER = %r!add_(?:runtime_)?dependency!
+      EXTRACT_DEPENDENCY_REGEX = %r!#{DEPENDENCY_MATCHER}(?:[(|\s])["'](.*?[^\\])["']!
+
+      # Returns an array of dependency gem-names.
+      attr_reader :theme_dependencies
+
+      def initialize(theme, whitelist)
+        @theme = theme
+        @whitelist = whitelist
+        @theme_dependencies = []
+      end
+
+      # Reads the gemspec at the given path, line-by-line, checking if the line
+      # contains a dependency declaration.
+      #
+      # Returns nothing, but stores the match in an array which can be accessed by
+      # calling +:theme_dependencies+
+      def extract_dependencies
+        return if @gemspec.nil? || !@theme_dependencies.empty?
+
+        File.read(@gemspec).each_line do |line|
+          next unless line =~ DEPENDENCY_MATCHER
+          line.match(EXTRACT_DEPENDENCY_REGEX)
+          @theme_dependencies << Regexp.last_match(1)
+        end
+      end
+
+      # Traverse the array of dependencies and +require+ the dependency if its
+      # whitelisted for current site.
+      #
+      # Returns nothing
+      def require_dependencies
+        theme_dependencies.each do |dependency|
+          next if dependency == "jekyll"
+          if @whitelist.include?(dependency)
+            Jekyll::External.require_with_graceful_fail(dependency)
+          end
+        end
+      end
+
+      # Returns the object as a debug String.
+      def inspect
+        "#<Jekyll::RemoteTheme::DependencyManager " \
+          "@gemspec=#{@gemspec.inspect} " \
+          "@theme_dependencies=#{@theme_dependencies}>"
+      end
+
+      private
+
+      def gemspec
+        @gemspec ||=
+          if File.exist?(nominal_gemspec)
+            nominal_gemspec
+          elsif !gemspec_files.empty?
+            gemspec_files[0]
+          end
+      end
+
+      # In the situation that the gemspec file(s) has not been named identical to the
+      # repository name, store an array of `.gemspec` file(s) at the root.
+      def gemspec_files
+        @gemspec_files ||= Jekyll::Utils.safe_glob(@theme.root, "*.gemspec")
+      end
+
+      def nominal_gemspec
+        @nominal_gemspec ||= File.expand_path(@theme.root, "#{theme.name}.gemspec")
+      end
+    end
+  end
+end

--- a/lib/jekyll-remote-theme/munger.rb
+++ b/lib/jekyll-remote-theme/munger.rb
@@ -24,6 +24,7 @@ module Jekyll
 
         downloader.run
         configure_theme
+        require_theme_dependencies
         enqueue_theme_cleanup
 
         theme
@@ -53,6 +54,11 @@ module Jekyll
         site.theme = theme
         site.theme.configure_sass
         site.send(:configure_include_paths)
+      end
+
+      def require_theme_dependencies
+        @deps_manager ||= DependencyManager.new(theme, site.config["whitelist"])
+        @deps_manager.require_dependencies
       end
 
       def enqueue_theme_cleanup

--- a/spec/fixtures/gemspecs/alldeps.gemspec
+++ b/spec/fixtures/gemspecs/alldeps.gemspec
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+lib = File.expand_path("lib", __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "alldeps/version"
+
+Gem::Specification.new do |s|
+  s.name    = "alldeps"
+  s.version = AllDeps::VERSION
+  s.authors = ["John Doe"]
+  s.summary = "Dummy gemspec"
+
+  # runtime dependencies
+  s.add_dependency "jekyll", "~> 3.5"
+  s.add_dependency "jekyll-feed", "~> 0.6"
+  s.add_dependency "jekyll-sitemap", "~> 1.5"
+
+  # development dependencies
+  s.add_dependency "bundler", "~> 1.12"
+  s.add_dependency "rake", "~> 10.0"
+end

--- a/spec/fixtures/gemspecs/braces.gemspec
+++ b/spec/fixtures/gemspecs/braces.gemspec
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+lib = File.expand_path("lib", __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "braces/version"
+
+Gem::Specification.new do |s|
+  s.name    = "braces"
+  s.version = Braces::VERSION
+  s.authors = ["John Doe"]
+  s.summary = "Dummy gemspec"
+
+  # rubocop:disable Style/StringLiterals
+  # runtime dependencies
+  s.add_dependency('jekyll',         "~> 3.5")
+  s.add_dependency('jekyll-feed',    "~> 0.6")
+  s.add_dependency('jekyll-sitemap', "~> 1.5")
+
+  # development dependencies
+  s.add_dependency('bundler',       "~> 1.12")
+  s.add_dependency('rake',          "~> 10.0")
+  # rubocop:enable Style/StringLiterals
+end

--- a/spec/fixtures/gemspecs/nodeps.gemspec
+++ b/spec/fixtures/gemspecs/nodeps.gemspec
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+lib = File.expand_path("lib", __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "nodeps/version"
+
+Gem::Specification.new do |s|
+  s.name    = "nodeps"
+  s.version = Lorem::VERSION
+  s.authors = ["John Doe"]
+  s.summary = "Dummy gemspec"
+
+  s.add_development_dependency("bundler", "~> 1.12")
+  s.add_development_dependency("rake",    "~> 10.0")
+end

--- a/spec/fixtures/gemspecs/rundev.gemspec
+++ b/spec/fixtures/gemspecs/rundev.gemspec
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+lib = File.expand_path("lib", __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "rundev/version"
+
+Gem::Specification.new do |spec|
+  spec.name    = "rundev"
+  spec.version = RunDev::VERSION
+  spec.authors = ["John Doe"]
+  spec.summary = "Dummy gemspec"
+
+  spec.add_runtime_dependency "jekyll", "~> 3.5"
+  spec.add_runtime_dependency "jekyll-feed", "~> 0.6" # some "random" comment
+  spec.add_runtime_dependency "jekyll-sitemap", "~> 1.5"
+
+  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "rake", "~> 10.0"
+end

--- a/spec/jekyll-remote-theme/dependency_manager_spec.rb
+++ b/spec/jekyll-remote-theme/dependency_manager_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe Jekyll::RemoteTheme::DependencyManager do
+  let(:theme) { Jekyll::RemoteTheme::Theme.new("owner/theme-name") }
+  let(:dependencies) { ["jekyll", "jekyll-feed", "jekyll-sitemap"] }
+  subject { described_class.new(theme, dependencies) }
+
+  %w(alldeps braces rundev).each do |name|
+    context "with #{name}.gemspec" do
+      it "returns an array of dependency gem names" do
+        subject.instance_variable_set(:@gemspec, gemspec_dir("#{name}.gemspec"))
+        subject.extract_dependencies
+        dependencies.each do |item|
+          expect(subject.theme_dependencies).to include(item)
+        end
+      end
+    end
+  end
+
+  context "with nodeps.gemspec" do
+    it "returns an empty dependency array" do
+      subject.instance_variable_set(:@gemspec, gemspec_dir("nodeps.gemspec"))
+      subject.extract_dependencies
+      expect(subject.theme_dependencies).to eql([])
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,10 @@ def dest_dir
   @dest_dir ||= File.join tmp_dir, "dest"
 end
 
+def gemspec_dir(*contents)
+  File.join(fixture_path("gemspecs"), *contents)
+end
+
 def reset_tmp_dir
   FileUtils.rm_rf tmp_dir
   FileUtils.mkdir_p tmp_dir


### PR DESCRIPTION
Improved version of #13 
  - The class concerns itself with just the remote-theme's gemspec and any (runtime_)dependencies declared within. All other content are ignored.
  - This class will auto-`require` whitelisted dependencies for the current site