### PR TITLE
Gem-based theme confusion/fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Jekyll plugin for building Jekyll sites with any GitHub-hosted theme
 
 Remote themes are specified by the `remote_theme` key in the site's config.
 
-Remote themes must be in the form of `OWNER/REPOSITORY`, and must represent a GitHub-hosted, Gem-based Jekyll theme. See [the Jekyll documentation](https://jekyllrb.com/docs/themes/) for more information on authoring a Gem-based theme.
+Remote themes must be in the form of `OWNER/REPOSITORY`, and must represent a GitHub-hosted Jekyll theme. See [the Jekyll documentation](https://jekyllrb.com/docs/themes/) for more information on authoring a theme. Note that you do not need to upload the gem to RubyGems or include a `.gemspec` file.
 
 You may also optionally specify a branch, tag, or commit to use by appending an `@` and the Git ref (e.g., `benbalter/retlab@v1.0.0` or `benbalter/retlab@develop`). If you don't specify a Git ref, the `master` branch will be used.
 

--- a/lib/jekyll-remote-theme/downloader.rb
+++ b/lib/jekyll-remote-theme/downloader.rb
@@ -90,7 +90,7 @@ module Jekyll
       end
 
       # Codeload generated zip files contain a top level folder in the form of
-      # THEME_NAME-GIT_REF/. While requests for Git repos are case incensitive,
+      # THEME_NAME-GIT_REF/. While requests for Git repos are case insensitive,
       # the zip subfolder will respect the case in the repository's name, thus
       # making it impossible to predict the true path to the theme. In case we're
       # on a case-sensitive file system, strip the parent folder from all paths.

--- a/lib/jekyll-remote-theme/mock_gemspec.rb
+++ b/lib/jekyll-remote-theme/mock_gemspec.rb
@@ -4,7 +4,7 @@ module Jekyll
   module RemoteTheme
     # Jekyll::Theme expects the theme's gemspec to tell it things like
     # the path to the theme and runtime dependencies. MockGemspec serves as a
-    # stand in, since remote themes don't have Gemspecs
+    # stand in, since remote themes don't need Gemspecs
     class MockGemspec
       extend Forwardable
       def_delegator :theme, :root, :full_gem_path

--- a/lib/jekyll-remote-theme/theme.rb
+++ b/lib/jekyll-remote-theme/theme.rb
@@ -4,7 +4,7 @@ module Jekyll
   module RemoteTheme
     class Theme < Jekyll::Theme
       OWNER_REGEX = %r!(?<owner>[a-z0-9\-]+)!i
-      NAME_REGEX  = %r!(?<name>[a-z0-9\-_]+)!i
+      NAME_REGEX  = %r!(?<name>[a-z0-9\._\-]+)!i
       REF_REGEX   = %r!@(?<ref>[a-z0-9\._\-]+)!i # May be a branch, tag, or commit
       THEME_REGEX = %r!\A#{OWNER_REGEX}/#{NAME_REGEX}(?:#{REF_REGEX})?\z!i
 


### PR DESCRIPTION
I was creating a theme to use on GitHub Pages and got a bit confused by the existing docs in this repository.

I've addressed a few documentation changes (in separate commits) and also added a fix to allow repository names to have `.`s in them. This is particularly useful if you're using an existing e.g. `foo.github.io` repository as a theme for another.