### PR TITLE
Use Net:HTTP instead of Typhoeus

### DIFF
--- a/jekyll-remote-theme.gemspec
+++ b/jekyll-remote-theme.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |s|
 
   s.add_dependency "jekyll", "~> 3.5"
   s.add_dependency "rubyzip", ">= 1.2.1", "< 3.0"
-  s.add_dependency "typhoeus", ">= 0.7", "< 2.0"
   s.add_development_dependency "jekyll-theme-primer", "~> 0.5"
   s.add_development_dependency "jekyll_test_plugin_malicious", "~> 0.2"
   s.add_development_dependency "pry", "~> 0.11"
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "rubocop", "~> 0.4", ">= 0.49.0"
+  s.add_development_dependency "webmock", "~> 3.0"
 end

--- a/lib/jekyll-remote-theme.rb
+++ b/lib/jekyll-remote-theme.rb
@@ -4,7 +4,7 @@ require "jekyll"
 require "fileutils"
 require "tempfile"
 require "addressable"
-require "typhoeus"
+require "open-uri"
 require "zip"
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
@@ -32,5 +32,3 @@ end
 Jekyll::Hooks.register :site, :after_reset do |site|
   Jekyll::RemoteTheme.init(site)
 end
-
-Ethon.logger = Jekyll.logger.writer

--- a/lib/jekyll-remote-theme.rb
+++ b/lib/jekyll-remote-theme.rb
@@ -4,7 +4,7 @@ require "jekyll"
 require "fileutils"
 require "tempfile"
 require "addressable"
-require "open-uri"
+require "net/http"
 require "zip"
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))

--- a/lib/jekyll-remote-theme/downloader.rb
+++ b/lib/jekyll-remote-theme/downloader.rb
@@ -27,8 +27,6 @@ module Jekyll
 
         download
         unzip
-
-        @downloaded = true
       end
 
       def downloaded?
@@ -52,6 +50,7 @@ module Jekyll
             end
           end
         end
+        @downloaded = true
       rescue *NET_HTTP_ERRORS => e
         raise DownloadError, e.message
       end

--- a/lib/jekyll-remote-theme/downloader.rb
+++ b/lib/jekyll-remote-theme/downloader.rb
@@ -52,7 +52,7 @@ module Jekyll
       def download
         Jekyll.logger.debug LOG_KEY, "Downloading #{zip_url} to #{zip_file.path}"
         io = URI(zip_url).open(OPTIONS)
-        IO.copy_stream io, zip_file.path
+        IO.copy_stream io, zip_file
         OpenURI::Meta.init zip_file, io
         zip_file
       rescue OpenURI::HTTPError, URI::InvalidURIError, SocketError => e

--- a/lib/jekyll-remote-theme/downloader.rb
+++ b/lib/jekyll-remote-theme/downloader.rb
@@ -8,15 +8,17 @@ module Jekyll
       MAX_FILE_SIZE = 1 * (1024 * 1024 * 1024) # Size in bytes (1 GB)
       OPTIONS = {
         "User-Agent"         => "Jekyll Remote Theme/#{VERSION} (+#{PROJECT_URL})",
-        :content_length_proc => lambda { |size|
-          if size && size > MAX_FILE_SIZE
-            raise DownloadError, "Maximum file size exceeded"
-          end
-        },
-        :progress_proc       => lambda { |size|
-          raise DownloadError, "Maximum file size exceeded" if size > MAX_FILE_SIZE
-        },
+        :content_length_proc => ->(size) { enforce_max_download_size!(size) },
+        :progress_proc       => ->(size) { enforce_max_download_size!(size) },
       }.freeze
+
+      class << self
+        private def enforce_max_download_size!(size)
+          if size && size > MAX_FILE_SIZE
+            raise DownloadError, "Maximum file size of #{MAX_FILE_SIZE} bytes exceeded"
+          end
+        end
+      end
 
       attr_reader :theme
       private :theme

--- a/lib/jekyll-remote-theme/downloader.rb
+++ b/lib/jekyll-remote-theme/downloader.rb
@@ -52,9 +52,12 @@ module Jekyll
         io = URI(zip_url).open(OPTIONS)
         IO.copy_stream io, zip_file.path
         OpenURI::Meta.init zip_file, io
-        io
+        zip_file
       rescue OpenURI::HTTPError, URI::InvalidURIError, SocketError => e
         raise DownloadError, "Request failed with #{e.message}"
+      ensure
+        io.close if io
+        io.unlink if io && io.respond_to?(:unlink)
       end
 
       def unzip
@@ -66,7 +69,8 @@ module Jekyll
         Zip::File.open(zip_file) do |archive|
           archive.each { |file| file.extract path_without_name_and_ref(file.name) }
         end
-
+      ensure
+        zip_file.close
         zip_file.unlink
       end
 

--- a/lib/jekyll-remote-theme/downloader.rb
+++ b/lib/jekyll-remote-theme/downloader.rb
@@ -8,6 +8,7 @@ module Jekyll
       MAX_FILE_SIZE = 1 * (1024 * 1024 * 1024) # Size in bytes (1 GB)
       OPTIONS = {
         "User-Agent"         => "Jekyll Remote Theme/#{VERSION} (+#{PROJECT_URL})",
+        :redirect            => false,
         :content_length_proc => ->(size) { enforce_max_file_size!(size) },
         :progress_proc       => ->(size) { enforce_max_file_size!(size) },
       }.freeze

--- a/lib/jekyll-remote-theme/downloader.rb
+++ b/lib/jekyll-remote-theme/downloader.rb
@@ -53,7 +53,7 @@ module Jekyll
         IO.copy_stream io, zip_file.path
         OpenURI::Meta.init zip_file, io
         io
-      rescue OpenURI::HTTPError => e
+      rescue OpenURI::HTTPError, URI::InvalidURIError, SocketError => e
         raise DownloadError, "Request failed with #{e.message}"
       end
 

--- a/lib/jekyll-remote-theme/downloader.rb
+++ b/lib/jekyll-remote-theme/downloader.rb
@@ -58,7 +58,7 @@ module Jekyll
       rescue OpenURI::HTTPError, URI::InvalidURIError, SocketError => e
         raise DownloadError, "Request failed with #{e.message}"
       ensure
-        io.close if io
+        io.close  if io
         io.unlink if io && io.respond_to?(:unlink)
       end
 

--- a/lib/jekyll-remote-theme/downloader.rb
+++ b/lib/jekyll-remote-theme/downloader.rb
@@ -8,12 +8,12 @@ module Jekyll
       MAX_FILE_SIZE = 1 * (1024 * 1024 * 1024) # Size in bytes (1 GB)
       OPTIONS = {
         "User-Agent"         => "Jekyll Remote Theme/#{VERSION} (+#{PROJECT_URL})",
-        :content_length_proc => ->(size) { enforce_max_download_size!(size) },
-        :progress_proc       => ->(size) { enforce_max_download_size!(size) },
+        :content_length_proc => ->(size) { enforce_max_file_size!(size) },
+        :progress_proc       => ->(size) { enforce_max_file_size!(size) },
       }.freeze
 
       class << self
-        private def enforce_max_download_size!(size)
+        private def enforce_max_file_size!(size)
           if size && size > MAX_FILE_SIZE
             raise DownloadError, "Maximum file size of #{MAX_FILE_SIZE} bytes exceeded"
           end

--- a/spec/jekyll-remote-theme/downloader_spec.rb
+++ b/spec/jekyll-remote-theme/downloader_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Jekyll::RemoteTheme::Downloader do
       after { WebMock.allow_net_connect! }
 
       it "raises a DownloadError" do
-        msg = "Request failed with 404 Not Found"
+        msg = "404 - Not Found"
         expect { subject.run }.to raise_error(Jekyll::RemoteTheme::DownloadError, msg)
       end
     end

--- a/spec/jekyll-remote-theme/downloader_spec.rb
+++ b/spec/jekyll-remote-theme/downloader_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Jekyll::RemoteTheme::Downloader do
       after { WebMock.allow_net_connect! }
 
       it "raises a DownloadError" do
-        msg = "Maximum file size exceeded"
+        msg = "Maximum file size of 1073741824 bytes exceeded"
         expect { subject.run }.to raise_error(Jekyll::RemoteTheme::DownloadError, msg)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require_relative "../lib/jekyll-remote-theme"
 require "fileutils"
 require "open3"
 require "pathname"
+require "webmock/rspec"
+WebMock.allow_net_connect!
 
 RSpec.configure do |config|
   config.example_status_persistence_file_path = "spec/examples.txt"


### PR DESCRIPTION
This PR moves the project to use ~~OpenURI~~ Net:HTTP to download themes, rather than Typhoeus. Typhoeus is a wrapper for Libcurl, which has Windows compatibility issues (https://github.com/benbalter/jekyll-remote-theme/issues/9, https://github.com/benbalter/jekyll-remote-theme/issues/18). ~~OpenURI~~ Net:HTTP is native Ruby, and thus shouldn't suffer from the same problems.

~~This implementation is largely based on https://twin.github.io/improving-open-uri/ and to a lesser extent https://gist.github.com/janko-m/7cd94b8b4dd113c2c193. I looked at using @janko-m's [Down](https://github.com/janko-m/down) which would provide a nice abstraction layer, but didn't want to add a dependency on a project with only 3 contributors (although it looks to be a great project).~~

For the most part, this approach appears to be a drop-in replacement, with tests passing with only minor modifications.

@parkr would you be able to review this?