### PR TITLE
Adding remote_theme_cache option to define a cache duration

### DIFF
--- a/lib/jekyll-remote-theme.rb
+++ b/lib/jekyll-remote-theme.rb
@@ -20,6 +20,7 @@ module Jekyll
     autoload :VERSION,     "jekyll-remote-theme/version"
 
     CONFIG_KEY  = "remote_theme".freeze
+    CACHE_KEY   = "remote_theme_cache".freeze
     LOG_KEY     = "Remote Theme:".freeze
     TEMP_PREFIX = "jekyll-remote-theme-".freeze
 

--- a/lib/jekyll-remote-theme/munger.rb
+++ b/lib/jekyll-remote-theme/munger.rb
@@ -43,8 +43,12 @@ module Jekyll
         config[CONFIG_KEY]
       end
 
+      def cache_duration
+        config[CACHE_KEY]
+      end
+
       def downloader
-        @downloader ||= Downloader.new(theme)
+        @downloader ||= Downloader.new(theme, cache_duration)
       end
 
       def configure_theme


### PR DESCRIPTION
Following up on #22 I hacked some proposal for a way to define a caching duration.

It uses a new config option, `remote_theme_caching` that takes the cache duration (in seconds).

When no value is set (which is the default), it will use the previous behavior. When a value is set, it will download the zip file to a specific cache location (still in the tmp folder). When subsequent builds are done, it will check if the file is older than the cache duration set. If not, it will re-use this file instead of re-downloading one. Otherwise, it will redownload it.

I based it on `v0.2.3` because that's what my `github-pages` gem is using locally. I haven't added any tests (yet), I wanted to have your feedback and seeing interest in this feature before going further.

Thanks!

