### PR TITLE
Add cache options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,14 @@ You may also optionally specify a branch, tag, or commit to use by appending an 
 ## Debugging
 
 Adding `--verbose` to the `build` or `serve` command may provide additional information.
+
+## Cache options when running locally
+
+If you are in a slow network, or the remote theme is so big that you don't want to download it every time, you can specify options in `_config.yml` to enable cache. If you only want to enable cache in development environment, you can create `_config.dev.yml`, and specify it in `serve` command like `jekyll serve -c _config.yml,_config.dev.yml`, this will make jekyll override the options from `_config.yml`.
+
+```yml
+remote_theme_cache_enabled: true
+remote_theme_cache_dir: <SPECIFIED_CACHE_DIR>
+```
+
+Add above options in your `_config.yml` file. By default the `remote_theme_cache_dir` is `~/.jekyll-remote-theme-cache`. Then start your server locally, the first time it will download the theme. After that, it will use the cache.

--- a/lib/jekyll-remote-theme.rb
+++ b/lib/jekyll-remote-theme.rb
@@ -19,9 +19,12 @@ module Jekyll
     autoload :Theme,       "jekyll-remote-theme/theme"
     autoload :VERSION,     "jekyll-remote-theme/version"
 
-    CONFIG_KEY  = "remote_theme".freeze
-    LOG_KEY     = "Remote Theme:".freeze
-    TEMP_PREFIX = "jekyll-remote-theme-".freeze
+    CONFIG_KEY               = "remote_theme".freeze
+    CONFIG_CACHE_ENABLED_KEY = "remote_theme_cache_enabled".freeze
+    CONFIG_CACHE_DIR_KEY     = "remote_theme_cache_dir".freeze
+    DEFAULT_CACHE_DIR        = "~/.jekyll-remote-theme-cache".freeze
+    LOG_KEY                  = "Remote Theme:".freeze
+    TEMP_PREFIX              = "jekyll-remote-theme-".freeze
 
     def self.init(site)
       Munger.new(site).munge!

--- a/lib/jekyll-remote-theme/theme.rb
+++ b/lib/jekyll-remote-theme/theme.rb
@@ -8,14 +8,17 @@ module Jekyll
       REF_REGEX   = %r!@(?<ref>[a-z0-9\._\-]+)!i # May be a branch, tag, or commit
       THEME_REGEX = %r!\A#{OWNER_REGEX}/#{NAME_REGEX}(?:#{REF_REGEX})?\z!i
 
+      attr_reader :options
+
       # Initializes a new Jekyll::RemoteTheme::Theme
       #
       # raw_theme can be in the form of:
       #
       # 1. owner/theme-name - a GitHub owner + theme-name string
       # 2. owner/theme-name@git_ref - a GitHub owner + theme-name + Git ref string
-      def initialize(raw_theme)
+      def initialize(raw_theme, options = {})
         @raw_theme = raw_theme.to_s.downcase.strip
+        @options = options
         super(@raw_theme)
       end
 
@@ -41,7 +44,14 @@ module Jekyll
       end
 
       def root
-        @root ||= File.realpath Dir.mktmpdir(TEMP_PREFIX)
+        @root ||=
+          if cache_dir = options[:cache_dir]
+            dir = File.join(cache_dir, "#{owner}_#{name}@#{git_ref}")
+            FileUtils.mkdir_p dir
+            dir
+          else
+            File.realpath Dir.mktmpdir(TEMP_PREFIX)
+          end
       end
 
       def inspect

--- a/spec/jekyll-remote-theme/theme_spec.rb
+++ b/spec/jekyll-remote-theme/theme_spec.rb
@@ -80,4 +80,15 @@ RSpec.describe Jekyll::RemoteTheme::Theme do
   it "exposes gemspec" do
     expect(subject.send(:gemspec)).to be_a(Jekyll::RemoteTheme::MockGemspec)
   end
+
+  context 'with cache dir' do
+    let(:cache_dir) { Dir.mktmpdir('foo') }
+    subject { described_class.new(raw_theme, cache_dir: cache_dir) }
+
+    it 'uses cache dir and theme info as root' do
+      root = subject.root
+      expect(Dir.exist?(root)).to be_truthy
+      expect(root).to eql(File.join("#{cache_dir}", "#{owner}_#{name}@master"))
+    end
+  end
 end


### PR DESCRIPTION
First of all, thanks for such a good plugin to get a theme from remote.

I want to use this remote theme https://github.com/mmistakes/minimal-mistakes. But when I configure my own settings and write blogs, every time I start the sever locally, it will download the remote theme. I'm in China, because of GFW, the download speed from github is so low that it may take several minutes to get the remote theme. When we need to restart jekyll server to make some settings applied, it will need to wait for several minutes, and it's very annoying. So I add this feature to enable cache.

Please consider whether this feature can be merged into this plugin. Thanks.