### PR TITLE
adds support for pessimistic semvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,12 @@ Remote themes are specified by the `remote_theme` key in the site's config.
 
 Remote themes must be in the form of `OWNER/REPOSITORY`, and must represent a public GitHub-hosted Jekyll theme. See [the Jekyll documentation](https://jekyllrb.com/docs/themes/) for more information on authoring a theme. Note that you do not need to upload the gem to RubyGems or include a `.gemspec` file.
 
-You may also optionally specify a branch, tag, or commit to use by appending an `@` and the Git ref (e.g., `benbalter/retlab@v1.0.0` or `benbalter/retlab@develop`). If you don't specify a Git ref, the `master` branch will be used.
+You may also optionally specify
+
+* a branch, tag, or commit to use by appending an `@` and the Git ref (e.g., `benbalter/retlab@v1.0.0` or `benbalter/retlab@develop`) or
+* a pessmistic version number by appending `~>` and a semver (e.g., `benbalter/retlab~>1.0.0`), the latter of which is assumed to be a tag (possibly starting with `v`).
+
+If you don't specify a Git ref or semver, the `master` branch will be used.
 
 ## Debugging
 

--- a/jekyll-remote-theme.gemspec
+++ b/jekyll-remote-theme.gemspec
@@ -15,8 +15,10 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.license       = "MIT"
 
+  s.add_dependency "git", "~> 1.3"
   s.add_dependency "jekyll", "~> 3.5"
   s.add_dependency "rubyzip", ">= 1.2.1", "< 3.0"
+  s.add_dependency "semantic", "~> 1.6"
   s.add_development_dependency "jekyll-theme-primer", "~> 0.5"
   s.add_development_dependency "jekyll_test_plugin_malicious", "~> 0.2"
   s.add_development_dependency "pry", "~> 0.11"

--- a/lib/jekyll-remote-theme.rb
+++ b/lib/jekyll-remote-theme.rb
@@ -6,6 +6,8 @@ require "tempfile"
 require "addressable"
 require "net/http"
 require "zip"
+require "git"
+require "semantic"
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 

--- a/lib/jekyll-remote-theme/version.rb
+++ b/lib/jekyll-remote-theme/version.rb
@@ -2,6 +2,6 @@
 
 module Jekyll
   module RemoteTheme
-    VERSION = "0.3.1"
+    VERSION = "0.4.0"
   end
 end


### PR DESCRIPTION
Implements https://github.com/benbalter/jekyll-remote-theme/issues/44, adding support for pessimistic versioning.

* Proposes to add support for:
  * `remote_theme: foo/bar~>1.6.5`
  * `remote_theme: foo/bar~>1.5`
  * `remote_theme: foo/bar~>3.7.9-pre.1+revision.15723 `
  * etc.
* Deliberately simpler than the comma-based format found in a `Gemfile` (e.g., `"foo/bar", "~> 1.6.5"`), to align it with the plugin's simple `@` syntax.
* Initially implemented for GitHub releases only (using [octokit.rb](https://github.com/octokit/octokit.rb)), but quickly hit API limits, which felt like a deal-breaker, especially in shared build environments, and requiring users to generate client IDs and secrets felt like excessive overhead. Instead using [ruby-git](https://github.com/ruby-git/ruby-git) to match against tags.
* If user specifies `foo/bar~>1.6.5`, will look for a tag called `1.6.5` (per SemVer 2), else looks for a tag called `v1.6.5` (per SemVer 1).
