### PR TITLE
Indicate the remote theme is being downloaded

### DIFF
--- a/lib/jekyll-remote-theme/munger.rb
+++ b/lib/jekyll-remote-theme/munger.rb
@@ -22,6 +22,7 @@ module Jekyll
         Jekyll.logger.info LOG_KEY, "Using theme #{theme.name_with_owner}"
         return theme if munged?
 
+        Jekyll.logger.info LOG_KEY, "Downloading..."
         downloader.run
         configure_theme
         enqueue_theme_cleanup


### PR DESCRIPTION
Write a log message that the remote theme is being downloaded, as otherwise it can appear no progress is being made.