### PR TITLE
Add ability to use themes hosted on enterprise GitHub instances.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,21 @@ Jekyll plugin for building Jekyll sites with any public GitHub-hosted theme
   ```yml
   remote_theme: benbalter/retlab
   ```
+or <sup>1</sup>
+  ```yml
+  remote_theme: http[s]://github.<Enterprise>.com/benbalter/retlab
+  ```
+<sup>1</sup> The codeload subdomain needs to be available on your github enterprise instance for this to work.
 
 ## Declaring your theme
 
 Remote themes are specified by the `remote_theme` key in the site's config.
 
-Remote themes must be in the form of `OWNER/REPOSITORY`, and must represent a public GitHub-hosted Jekyll theme. See [the Jekyll documentation](https://jekyllrb.com/docs/themes/) for more information on authoring a theme. Note that you do not need to upload the gem to RubyGems or include a `.gemspec` file.
+For public GitHub, remote themes must be in the form of `OWNER/REPOSITORY`, and must represent a public GitHub-hosted Jekyll theme. See [the Jekyll documentation](https://jekyllrb.com/docs/themes/) for more information on authoring a theme. Note that you do not need to upload the gem to RubyGems or include a `.gemspec` file.
 
 You may also optionally specify a branch, tag, or commit to use by appending an `@` and the Git ref (e.g., `benbalter/retlab@v1.0.0` or `benbalter/retlab@develop`). If you don't specify a Git ref, the `master` branch will be used.
+
+For Enterprise GitHub, remote themes must be in the form of `http[s]://GITHUBHOST.com/OWNER/REPOSITORY`, and must represent a public (non-private repository) GitHub-hosted Jekyll theme. Other than requiring the fully qualified domain name of the enterprise GitHub instance, this works exactly the same as the public usage.
 
 ## Debugging
 

--- a/jekyll-remote-theme.gemspec
+++ b/jekyll-remote-theme.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.license       = "MIT"
 
+  s.add_dependency "addressable", "~> 2.0"
   s.add_dependency "jekyll", "~> 3.5"
   s.add_dependency "rubyzip", ">= 1.2.1", "< 3.0"
   s.add_development_dependency "jekyll-theme-primer", "~> 0.5"

--- a/lib/jekyll-remote-theme/downloader.rb
+++ b/lib/jekyll-remote-theme/downloader.rb
@@ -89,8 +89,10 @@ module Jekyll
 
       # Full URL to codeload zip download endpoint for the given theme
       def zip_url
-        @zip_url ||= Addressable::URI.join(
-          "#{theme.host}/", "#{theme.owner}/", "#{theme.name}/", "zip/", theme.git_ref
+        @zip_url ||= Addressable::URI.new(
+          :scheme => theme.scheme,
+          :host   => "codeload.#{theme.host}",
+          :path   => [theme.owner, theme.name, "zip", theme.git_ref].join("/")
         ).normalize
       end
 

--- a/lib/jekyll-remote-theme/downloader.rb
+++ b/lib/jekyll-remote-theme/downloader.rb
@@ -3,7 +3,6 @@
 module Jekyll
   module RemoteTheme
     class Downloader
-      HOST = "https://codeload.github.com"
       PROJECT_URL = "https://github.com/benbalter/jekyll-remote-theme"
       USER_AGENT = "Jekyll Remote Theme/#{VERSION} (+#{PROJECT_URL})"
       MAX_FILE_SIZE = 1 * (1024 * 1024 * 1024) # Size in bytes (1 GB)
@@ -91,7 +90,7 @@ module Jekyll
       # Full URL to codeload zip download endpoint for the given theme
       def zip_url
         @zip_url ||= Addressable::URI.join(
-          HOST, "#{theme.owner}/", "#{theme.name}/", "zip/", theme.git_ref
+          "#{theme.host}/", "#{theme.owner}/", "#{theme.name}/", "zip/", theme.git_ref
         ).normalize
       end
 

--- a/lib/jekyll-remote-theme/version.rb
+++ b/lib/jekyll-remote-theme/version.rb
@@ -2,6 +2,6 @@
 
 module Jekyll
   module RemoteTheme
-    VERSION = "0.3.1"
+    VERSION = "0.4.0"
   end
 end

--- a/lib/jekyll-remote-theme/version.rb
+++ b/lib/jekyll-remote-theme/version.rb
@@ -2,6 +2,6 @@
 
 module Jekyll
   module RemoteTheme
-    VERSION = "0.4.0"
+    VERSION = "0.3.1"
   end
 end

--- a/spec/jekyll-remote-theme/downloader_spec.rb
+++ b/spec/jekyll-remote-theme/downloader_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Jekyll::RemoteTheme::Downloader do
-  let(:nwo) { "pages-themes/primer" }
-  let(:theme) { Jekyll::RemoteTheme::Theme.new(nwo) }
+  let(:raw_theme) { "pages-themes/primer" }
+  let(:theme) { Jekyll::RemoteTheme::Theme.new(raw_theme) }
   subject { described_class.new(theme) }
 
   before { reset_tmp_dir }
@@ -37,6 +37,22 @@ RSpec.describe Jekyll::RemoteTheme::Downloader do
 
     it "knows the theme dir isn't empty" do
       expect(subject.send(:theme_dir_empty?)).to be_falsy
+    end
+  end
+
+  context "zip_url" do
+    it "builds the zip url" do
+      expected = "https://codeload.github.com/pages-themes/primer/zip/master"
+      expect(subject.send(:zip_url).to_s).to eql(expected)
+    end
+
+    context "a custom host" do
+      let(:raw_theme) { "http://example.com/pages-themes/primer" }
+
+      it "builds the zip url" do
+        expected = "http://codeload.example.com/pages-themes/primer/zip/master"
+        expect(subject.send(:zip_url).to_s).to eql(expected)
+      end
     end
   end
 

--- a/spec/jekyll-remote-theme/theme_spec.rb
+++ b/spec/jekyll-remote-theme/theme_spec.rb
@@ -1,11 +1,19 @@
 # frozen_string_literal: true
 
 RSpec.describe Jekyll::RemoteTheme::Theme do
+  let(:scheme) { nil }
+  let(:host) { nil }
   let(:owner) { "foo" }
   let(:name) { "bar" }
   let(:nwo) { "#{owner}/#{name}" }
   let(:git_ref) { nil }
-  let(:raw_theme) { git_ref ? "#{nwo}@#{git_ref}" : nwo }
+  let(:raw_theme) do
+    raw_theme = +""
+    raw_theme << "#{scheme}://#{host}/" if scheme && host
+    raw_theme << nwo.to_s
+    raw_theme << "@#{git_ref}" if git_ref
+    raw_theme
+  end
   subject { described_class.new(raw_theme) }
 
   it "stores the theme" do
@@ -26,6 +34,14 @@ RSpec.describe Jekyll::RemoteTheme::Theme do
 
   it "extracts the owner" do
     expect(subject.owner).to eql(owner)
+  end
+
+  it "uses the default host" do
+    expect(subject.host).to eql("github.com")
+  end
+
+  it "uses the default scheme" do
+    expect(subject.scheme).to eql("https")
   end
 
   it "builds the name with owner" do
@@ -79,5 +95,73 @@ RSpec.describe Jekyll::RemoteTheme::Theme do
 
   it "exposes gemspec" do
     expect(subject.send(:gemspec)).to be_a(Jekyll::RemoteTheme::MockGemspec)
+  end
+
+  context "a full URL" do
+    let(:host) { "github.com" }
+    let(:scheme) { "https" }
+
+    it "extracts the name" do
+      expect(subject.name).to eql(name)
+    end
+
+    it "extracts the owner" do
+      expect(subject.owner).to eql(owner)
+    end
+
+    it "extracts the host" do
+      expect(subject.host).to eql("github.com")
+    end
+
+    it "extracts the scheme" do
+      expect(subject.scheme).to eql("https")
+    end
+
+    it "is valid" do
+      with_env "GITHUB_HOSTNAME", "enterprise.github.com" do
+        expect(subject).to be_valid
+      end
+    end
+
+    context "a custom host" do
+      let(:host) { "example.com" }
+      let(:scheme) { "http" }
+
+      it "extracts the name" do
+        expect(subject.name).to eql(name)
+      end
+
+      it "extracts the owner" do
+        expect(subject.owner).to eql(owner)
+      end
+
+      it "extracts the host" do
+        expect(subject.host).to eql(host)
+      end
+
+      it "extracts the scheme" do
+        expect(subject.scheme).to eql(scheme)
+      end
+
+      it "is valid if a whitelisted host name" do
+        with_env "GITHUB_HOSTNAME", "example.com" do
+          expect(subject).to be_valid
+        end
+      end
+
+      it "is invalid if not a whitelisted host name" do
+        with_env "GITHUB_HOSTNAME", "enterprise.github.com" do
+          expect(subject).to_not be_valid
+        end
+      end
+
+      context "with a git ref" do
+        let(:git_ref) { "foo" }
+
+        it "parses the git ref" do
+          expect(subject.git_ref).to eql(git_ref)
+        end
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,3 +57,10 @@ def make_site(options = {})
   config = Jekyll.configuration config_defaults.merge(options)
   Jekyll::Site.new(config)
 end
+
+def with_env(key, value)
+  old_env = ENV[key]
+  ENV[key] = value
+  yield
+  ENV[key] = old_env
+end


### PR DESCRIPTION
I'd like to use this for repos hosted in our enterprise instance at work (as would several of my coworkers) so I thought I would throw this against the wall and see if it stuck. I'm not a ruby programmer, so any stylistic feedback is welcome. 
Fixes #43 

-----
[View rendered README.md](https://github.com/jallenwork/jekyll-remote-theme/blob/enterprise/README.md)