### PR TITLE
Upgrade rubyzip to version 1.3.0 or later

### DIFF
--- a/jekyll-remote-theme.gemspec
+++ b/jekyll-remote-theme.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "addressable", "~> 2.0"
   s.add_dependency "jekyll", ">= 3.5", "< 5.0"
-  s.add_dependency "rubyzip", ">= 1.2.1", "< 3.0"
+  s.add_dependency "rubyzip", ">= 1.3.0"
   s.add_development_dependency "jekyll-theme-primer", "~> 0.5"
   s.add_development_dependency "jekyll_test_plugin_malicious", "~> 0.2"
   s.add_development_dependency "pry", "~> 0.11"


### PR DESCRIPTION
> In Rubyzip before 1.3.0, a crafted ZIP file can bypass application checks on ZIP entry sizes because data about the uncompressed size can be spoofed. This allows attackers to cause a denial of service (disk consumption).
>
> -- https://nvd.nist.gov/vuln/detail/CVE-2019-16892