### PR TITLE
added a percent downloaded printout in the jekyll logger 

### DIFF
--- a/jekyll-remote-theme.gemspec
+++ b/jekyll-remote-theme.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "addressable", "~> 2.0"
   s.add_dependency "jekyll", ">= 3.5", "< 5.0"
   s.add_dependency "jekyll-sass-converter", ">= 1.0", "<= 3.0.0", "!= 2.0.0"
+  s.add_dependency "ruby-progressbar", "~> 1.0"
   s.add_dependency "rubyzip", ">= 1.3.0", "< 3.0"
 
   s.add_development_dependency "jekyll-theme-primer", "~> 0.5"

--- a/lib/jekyll-remote-theme.rb
+++ b/lib/jekyll-remote-theme.rb
@@ -6,6 +6,7 @@ require "tempfile"
 require "addressable"
 require "net/http"
 require "zip"
+require "ruby-progressbar"
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 

--- a/lib/jekyll-remote-theme/downloader.rb
+++ b/lib/jekyll-remote-theme/downloader.rb
@@ -42,9 +42,15 @@ module Jekyll
         Net::HTTP.start(zip_url.host, zip_url.port, :use_ssl => true) do |http|
           http.request(request) do |response|
             raise_unless_sucess(response)
-            enforce_max_file_size(response.content_length)
+            file_size = response['content-length'].to_i
+            enforce_max_file_size(file_size)
+            amount_downloaded = 0
             response.read_body do |chunk|
               zip_file.write chunk
+              if file_size > 0
+                amount_downloaded += chunk.size
+                Jekyll.logger.info("\r%d%% downloaded" % (amount_downloaded.to_f / file_size * 100))
+              end
             end
           end
         end


### PR DESCRIPTION
in case fetching the remote theme takes a while. This addresses #65.

This is the absolutely first thing I've ever done in Ruby, so hopefully it actually works as intended. The tests all still pass (in my environment when my internet connection is good enough), but I actually don't know how to run exactly as `jekyll serve` would call it, so I'm not sure what the result looks like user-side.

Mostly I played with my own copy of the answer to [this stackoverflow question](https://stackoverflow.com/questions/26878587/nethttp-get-show-progress) until I was sure I could adequately replicate the structure. But all the themes downloaded in tests are small, so the status just goes directly to 100%.

