### PR TITLE
feat: Include _data from theme in sites that use the theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ spec/examples.txt
 *.gem
 tmp/
 spec/fixtures/site/.jekyll-cache
+vendor/

--- a/spec/jekyll-remote-theme/munger_spec.rb
+++ b/spec/jekyll-remote-theme/munger_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Jekyll::RemoteTheme::Munger do
   let(:sass_dir) { File.expand_path "_sass/", theme_dir }
   let(:sass_path) { File.expand_path "jekyll-theme-primer.scss", sass_dir }
   let(:includes_dir) { File.expand_path "_includes/", theme_dir }
+  let(:includes_dir) { File.expand_path "_data", theme_dir }
   let(:theme) { subject.send(:theme) }
 
   subject { described_class.new(site) }
@@ -94,6 +95,10 @@ RSpec.describe Jekyll::RemoteTheme::Munger do
       site.read
       expect(site.layouts["default"]).to be_truthy
       expect(site.layouts["default"].path).to eql(layout_path)
+    end
+
+    it "sets data path" do
+      expect(site.data_load_paths).to include(includes_dir)
     end
 
     it "requires plugins" do


### PR DESCRIPTION
---
name: Include _data from theme in sites that use the theme
about: #68 
---

### Is your feature request related to a problem? Please describe the problem you're trying to solve.

This feature could be useful for i18n and/or l10n, when building multilingual theme and the 118n strings sits in _data folder. In case of conflicts the files in _data can always be overridden like the _includes and _laytouts folders are.

### Describe the solution you'd like

Modification of the munger_spec.rb to allow files in _data to be called by the theme