### PR TITLE
remove the temp remote theme dirs created by the tests

### DIFF
--- a/spec/jekyll-remote-theme/downloader_spec.rb
+++ b/spec/jekyll-remote-theme/downloader_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Jekyll::RemoteTheme::Downloader do
   subject { described_class.new(theme) }
 
   before { reset_tmp_dir }
+  after { FileUtils.rm_rf theme.root if Dir.exist?(theme.root) }
 
   it "knows it's not downloaded" do
     expect(subject.downloaded?).to be_falsy
@@ -17,7 +18,6 @@ RSpec.describe Jekyll::RemoteTheme::Downloader do
 
   context "downloading" do
     before { subject.run }
-    after { FileUtils.rm_rf theme.root if Dir.exist?(theme.root) }
 
     it "knows it's downloaded" do
       expect(subject.downloaded?).to be_truthy

--- a/spec/jekyll-remote-theme/mock_gemspec_spec.rb
+++ b/spec/jekyll-remote-theme/mock_gemspec_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Jekyll::RemoteTheme::MockGemspec do
   subject { described_class.new(theme) }
 
   before { File.write path, contents }
+  after { FileUtils.rm_rf theme.root if Dir.exist?(theme.root) }
 
   it "stores the theme" do
     expect(subject.send(:theme)).to eql(theme)

--- a/spec/jekyll-remote-theme/munger_spec.rb
+++ b/spec/jekyll-remote-theme/munger_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Jekyll::RemoteTheme::Munger do
 
   before { Jekyll.logger.log_level = :error }
   before { reset_tmp_dir }
+  after { FileUtils.rm_rf theme.root if Dir.exist?(theme.root) }
 
   # Remove :after_reset hook to allow themes to be stubbed prior to munging
   before(:each) do

--- a/spec/jekyll-remote-theme/theme_spec.rb
+++ b/spec/jekyll-remote-theme/theme_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Jekyll::RemoteTheme::Theme do
     raw_theme
   end
   subject { described_class.new(raw_theme) }
+  after { FileUtils.rm_rf subject.root if Dir.exist?(subject.root) }
 
   it "stores the theme" do
     expect(subject.instance_variable_get("@raw_theme")).to eql(nwo)


### PR DESCRIPTION
Greetings:

Whilst running the test to see if the changes that were made in the last PR caused any of the tests to fail, I noticed that the tests create remote theme folders in the temp directory. However, the tests did not clean up after itself. The tests did not remove the remote theme folders that it created in the temp directory. This PR updates the tests so that it cleans up after itself.