### PR TITLE
Added extra context to error message when remote theme download fails

### DIFF
--- a/lib/jekyll-remote-theme/downloader.rb
+++ b/lib/jekyll-remote-theme/downloader.rb
@@ -64,7 +64,7 @@ module Jekyll
       def raise_unless_sucess(response)
         return if response.is_a?(Net::HTTPSuccess)
 
-        raise DownloadError, "#{response.code} - #{response.message}"
+        raise DownloadError, "#{response.code} - #{response.message} - Loading URL: #{zip_url}"
       end
 
       def enforce_max_file_size(size)

--- a/spec/jekyll-remote-theme/downloader_spec.rb
+++ b/spec/jekyll-remote-theme/downloader_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Jekyll::RemoteTheme::Downloader do
       after { WebMock.allow_net_connect! }
 
       it "raises a DownloadError" do
-        msg = "404 - Not Found"
+        msg = "404 - Not Found - Loading URL: https://codeload.github.com/benbalter/_invalid_/zip/master"
         expect { subject.run }.to raise_error(Jekyll::RemoteTheme::DownloadError, msg)
       end
     end


### PR DESCRIPTION
This is an attempt to help give a pointer to why the download may be failing after a remote theme changes to using a default branch of `main` rather than `master`.

It relates to https://github.com/benbalter/jekyll-remote-theme/issues/59 (where @parkr proposed something like this) and https://github.com/benbalter/jekyll-remote-theme/issues/84 (where this has cropped up more recently).

Note that my Ruby is real rusty, so forgive me if this is not quite in the ideal standards.