### PR TITLE
Require kramdown-parser-gfm to fix travis

### DIFF
--- a/jekyll-remote-theme.gemspec
+++ b/jekyll-remote-theme.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "jekyll-theme-primer", "~> 0.5"
   s.add_development_dependency "jekyll_test_plugin_malicious", "~> 0.2"
+  s.add_development_dependency "kramdown-parser-gfm", "~> 1.0"
   s.add_development_dependency "pry", "~> 0.11"
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "rubocop", "~> 0.71"

--- a/lib/jekyll-remote-theme/theme.rb
+++ b/lib/jekyll-remote-theme/theme.rb
@@ -68,7 +68,7 @@ module Jekyll
       def uri
         return @uri if defined? @uri
 
-        @uri = if @raw_theme =~ THEME_REGEX
+        @uri = if THEME_REGEX.match?(@raw_theme)
                  Addressable::URI.new(
                    :scheme => "https",
                    :host   => "github.com",


### PR DESCRIPTION
Hopeful fix for the errors seen in https://travis-ci.org/github/benbalter/jekyll-remote-theme/jobs/759459112.