### PR TITLE
Updated to use HEAD instead of master as default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Remote themes are specified by the `remote_theme` key in the site's config.
 
 For public GitHub, remote themes must be in the form of `OWNER/REPOSITORY`, and must represent a public GitHub-hosted Jekyll theme. See [the Jekyll documentation](https://jekyllrb.com/docs/themes/) for more information on authoring a theme. Note that you do not need to upload the gem to RubyGems or include a `.gemspec` file.
 
-You may also optionally specify a branch, tag, or commit to use by appending an `@` and the Git ref (e.g., `benbalter/retlab@v1.0.0` or `benbalter/retlab@develop`). If you don't specify a Git ref, the `master` branch will be used.
+You may also optionally specify a branch, tag, or commit to use by appending an `@` and the Git ref (e.g., `benbalter/retlab@v1.0.0` or `benbalter/retlab@develop`). If you don't specify a Git ref, the `HEAD` branch will be used.
 
 For Enterprise GitHub, remote themes must be in the form of `http[s]://GITHUBHOST.com/OWNER/REPOSITORY`, and must represent a public (non-private repository) GitHub-hosted Jekyll theme. Other than requiring the fully qualified domain name of the enterprise GitHub instance, this works exactly the same as the public usage.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Remote themes are specified by the `remote_theme` key in the site's config.
 
 For public GitHub, remote themes must be in the form of `OWNER/REPOSITORY`, and must represent a public GitHub-hosted Jekyll theme. See [the Jekyll documentation](https://jekyllrb.com/docs/themes/) for more information on authoring a theme. Note that you do not need to upload the gem to RubyGems or include a `.gemspec` file.
 
-You may also optionally specify a branch, tag, or commit to use by appending an `@` and the Git ref (e.g., `benbalter/retlab@v1.0.0` or `benbalter/retlab@develop`). If you don't specify a Git ref, the `HEAD` branch will be used.
+You may also optionally specify a branch, tag, or commit to use by appending an `@` and the Git ref (e.g., `benbalter/retlab@v1.0.0` or `benbalter/retlab@develop`). If you don't specify a Git ref, the `HEAD` ref will be used.
 
 For Enterprise GitHub, remote themes must be in the form of `http[s]://GITHUBHOST.com/OWNER/REPOSITORY`, and must represent a public (non-private repository) GitHub-hosted Jekyll theme. Other than requiring the fully qualified domain name of the enterprise GitHub instance, this works exactly the same as the public usage.
 

--- a/lib/jekyll-remote-theme/theme.rb
+++ b/lib/jekyll-remote-theme/theme.rb
@@ -51,7 +51,7 @@ module Jekyll
       end
 
       def git_ref
-        theme_parts[:ref] || "master"
+        theme_parts[:ref] || "HEAD"
       end
 
       def root

--- a/spec/jekyll-remote-theme/downloader_spec.rb
+++ b/spec/jekyll-remote-theme/downloader_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Jekyll::RemoteTheme::Downloader do
 
   context "zip_url" do
     it "builds the zip url" do
-      expected = "https://codeload.github.com/pages-themes/primer/zip/master"
+      expected = "https://codeload.github.com/pages-themes/primer/zip/HEAD"
       expect(subject.send(:zip_url).to_s).to eql(expected)
     end
 
@@ -50,7 +50,7 @@ RSpec.describe Jekyll::RemoteTheme::Downloader do
       let(:raw_theme) { "http://example.com/pages-themes/primer" }
 
       it "builds the zip url" do
-        expected = "http://codeload.example.com/pages-themes/primer/zip/master"
+        expected = "http://codeload.example.com/pages-themes/primer/zip/HEAD"
         expect(subject.send(:zip_url).to_s).to eql(expected)
       end
     end
@@ -60,7 +60,7 @@ RSpec.describe Jekyll::RemoteTheme::Downloader do
     before { allow(subject).to receive(:zip_url) { Addressable::URI.parse zip_url } }
 
     context "with an invalid URL" do
-      let(:zip_url) { "https://codeload.github.com/benbalter/_invalid_/zip/master" }
+      let(:zip_url) { "https://codeload.github.com/benbalter/_invalid_/zip/HEAD" }
       before do
         WebMock.disable_net_connect!
         stub_request(:get, zip_url).to_return(:status => [404, "Not Found"])
@@ -69,13 +69,13 @@ RSpec.describe Jekyll::RemoteTheme::Downloader do
       after { WebMock.allow_net_connect! }
 
       it "raises a DownloadError" do
-        msg = "404 - Not Found - Loading URL: https://codeload.github.com/benbalter/_invalid_/zip/master"
+        msg = "404 - Not Found - Loading URL: https://codeload.github.com/benbalter/_invalid_/zip/HEAD"
         expect { subject.run }.to raise_error(Jekyll::RemoteTheme::DownloadError, msg)
       end
     end
 
     context "with a large file" do
-      let(:zip_url) { "https://codeload.github.com/benbalter/_invalid_/zip/master" }
+      let(:zip_url) { "https://codeload.github.com/benbalter/_invalid_/zip/HEAD" }
       let(:content_length) { 10 * 1024 * 1024 * 1024 }
       let(:headers) { { "Content-Length" => content_length } }
       before do

--- a/spec/jekyll-remote-theme/theme_spec.rb
+++ b/spec/jekyll-remote-theme/theme_spec.rb
@@ -77,8 +77,8 @@ RSpec.describe Jekyll::RemoteTheme::Theme do
     end
   end
 
-  it "defaults git_ref to master" do
-    expect(subject.git_ref).to eql("master")
+  it "defaults git_ref to HEAD" do
+    expect(subject.git_ref).to eql("HEAD")
   end
 
   context "with a git_ref" do


### PR DESCRIPTION
Resolves #84, Builds off work in #85.

-----
[View rendered README.md](https://github.com/IanLee1521/jekyll-remote-theme/blob/default-branch-head/README.md)