### PR TITLE
Propagate _data folder from remote theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,7 @@ For Enterprise GitHub, remote themes must be in the form of `http[s]://GITHUBHOS
 ## Debugging
 
 Adding `--verbose` to the `build` or `serve` command may provide additional information.
+
+## Catalogues
+
+In addition to the default directories `assets`, `_includes`, `_layouts`, and `_sass` you can now also host catalogues in your remote theme’s `_data` directory as supposed in #68.  

--- a/lib/jekyll-remote-theme.rb
+++ b/lib/jekyll-remote-theme.rb
@@ -13,18 +13,22 @@ module Jekyll
   module RemoteTheme
     class DownloadError < StandardError; end
 
-    autoload :Downloader,  "jekyll-remote-theme/downloader"
-    autoload :MockGemspec, "jekyll-remote-theme/mock_gemspec"
-    autoload :Munger,      "jekyll-remote-theme/munger"
-    autoload :Theme,       "jekyll-remote-theme/theme"
-    autoload :VERSION,     "jekyll-remote-theme/version"
+    autoload :Downloader,       "jekyll-remote-theme/downloader"
+    autoload :MockGemspec,      "jekyll-remote-theme/mock_gemspec"
+    autoload :Munger,           "jekyll-remote-theme/munger"
+    autoload :Theme,            "jekyll-remote-theme/theme"
+    autoload :Reader,           "jekyll-remote-theme/reader"
+    autoload :ThemeDataReader,  "jekyll-remote-theme/theme_data_reader"
+    autoload :VERSION,          "jekyll-remote-theme/version"
 
     CONFIG_KEY  = "remote_theme"
     LOG_KEY     = "Remote Theme:"
     TEMP_PREFIX = "jekyll-remote-theme-"
 
     def self.init(site)
-      Munger.new(site).munge!
+      @theme = Munger.new(site).munge!
+      site.reader = Reader.new(site)
+      @theme
     end
   end
 end

--- a/lib/jekyll-remote-theme/reader.rb
+++ b/lib/jekyll-remote-theme/reader.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "csv"
+module Jekyll
+  module RemoteTheme
+    class Reader < Jekyll::Reader
+      def initialize(site)
+        @site = site
+        @theme = site.theme
+      end
+
+      def read
+        super
+
+        if @theme.data_path
+          theme_data = ThemeDataReader.new(site).read(site.config["data_dir"])
+          @site.data = Jekyll::Utils.deep_merge_hashes(theme_data, @site.data)
+        end
+      end
+    end
+  end
+end

--- a/lib/jekyll-remote-theme/theme.rb
+++ b/lib/jekyll-remote-theme/theme.rb
@@ -63,6 +63,10 @@ module Jekyll
         " ref=\"#{git_ref}\" root=\"#{root}\">"
       end
 
+      def data_path
+        @data_path ||= File.join(@root, "_data")
+      end
+
       private
 
       def uri

--- a/lib/jekyll-remote-theme/theme_data_reader.rb
+++ b/lib/jekyll-remote-theme/theme_data_reader.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module RemoteTheme
+    class ThemeDataReader < Jekyll::DataReader
+      attr_reader :site, :content
+
+      def read(dir)
+        return unless site.theme&.data_path
+
+        base = site.in_theme_dir(dir)
+        read_data_to(base, @content)
+        @content
+      end
+
+      def read_data_to(dir, data)
+        return unless File.directory?(dir) && !@entry_filter.symlink?(dir)
+
+        entries = Dir.chdir(dir) do
+          Dir["*.{yaml,yml,json,csv,tsv}"] + Dir["*"].select { |fn| File.directory?(fn) }
+        end
+
+        entries.each do |entry|
+          path = @site.in_theme_dir(dir, entry)
+          next if @entry_filter.symlink?(path)
+
+          if File.directory?(path)
+            read_data_to(path, data[sanitize_filename(entry)] = {})
+          else
+            key = sanitize_filename(File.basename(entry, ".*"))
+            data[key] = read_data_file(path)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
All files from _data folder within remote theme are accessible in consumer projects. The behaviour is exactly the same as for overrides of _includes and _layouts. Data files with the same name in consumer project override data files within remote theme.
As supposed by @hblankenship and @desima in #68 

-----
[View rendered README.md](https://github.com/mgerzabek/jekyll-remote-theme/blob/with_data_folder/README.md)