### PR TITLE
Prepare 0.5.0 release

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,32 @@
+# History
+
+## 0.5.0
+
+### Features
+
+- Add `@latest` ref to automatically use the latest GitHub release (#126)
+- Add support for local filesystem paths in `remote_theme` configuration (#120)
+- Add corporate proxy support for remote theme downloads (#124)
+
+### Fixes
+
+- Improve 404 error message for non-existent remote themes (#110)
+- Fix Ruby 3.4 SSL/CRL compatibility issue (#118)
+- Fix compatibility with jekyll-github-metadata 2.15.0+ (#122)
+- Add gemspec metadata methods to `MockGemspec` for remote theme compatibility (#125)
+- Add tests and documentation for local file override behavior (#123)
+
+### Dependencies
+
+- Bump jekyll-sass-converter to allow 3.1.0 (#127)
+- Bump actions/checkout from 2 to 6 (#115)
+- Bump github/codeql-action from 1 to 3 (#108)
+- Upgrade to GitHub-native Dependabot (#92)
+
+### Infrastructure
+
+- Move from Travis to GitHub Actions for CI (#106)
+
+## 0.4.3
+
+See [the GitHub release notes](https://github.com/benbalter/jekyll-remote-theme/releases/tag/v0.4.3).

--- a/lib/jekyll-remote-theme/version.rb
+++ b/lib/jekyll-remote-theme/version.rb
@@ -2,6 +2,6 @@
 
 module Jekyll
   module RemoteTheme
-    VERSION = "0.4.3"
+    VERSION = "0.5.0"
   end
 end


### PR DESCRIPTION
## Summary

- Bump `VERSION` to 0.5.0
- Add `HISTORY.md` documenting changes since v0.4.3 (March 2021)

This is the first release in 4+ years. A minor bump (vs. patch) reflects new functionality: local filesystem paths in `remote_theme`, `@latest` ref support, and corporate proxy support.

### Highlights since v0.4.3

- **Features**: `@latest` ref (#126), local filesystem paths (#120), corporate proxy support (#124)
- **Fixes**: Ruby 3.4 SSL/CRL compatibility (#118), jekyll-github-metadata 2.15+ compat (#122), 404 error message (#110), `MockGemspec` metadata methods (#125), local file overrides (#123)
- **Dependencies**: jekyll-sass-converter 3.x (#127), actions/checkout v6 (#115), codeql-action v3 (#108), GitHub-native Dependabot (#92)
- **Infrastructure**: Move CI from Travis to GitHub Actions (#106)

See `HISTORY.md` for the full list.

## Test plan

- [x] `bundle exec rspec` — 135 examples, 0 failures
- [x] `gem build jekyll-remote-theme.gemspec` builds as `jekyll-remote-theme-0.5.0.gem`
- [ ] CI green (rubocop runs against Ruby 3.3 in CI; the stale `~> 0.71` pin crashes on Ruby 4.x locally but is out of scope here)

## Follow-ups (not in this PR)

- Delete stale draft release `untagged-e7e4b60868debfc53321` (release-drafter remnant from 2021) before tagging v0.5.0
- After merge: tag `v0.5.0`, let release-drafter publish, then `gem push`

🤖 Generated with [Claude Code](https://claude.com/claude-code)