### PR TITLE
Allow openssl 4.x to fix install on Ruby 4.0

### DIFF
--- a/jekyll-remote-theme.gemspec
+++ b/jekyll-remote-theme.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "addressable", "~> 2.0"
   s.add_dependency "jekyll", ">= 3.5", "< 5.0"
   s.add_dependency "jekyll-sass-converter", ">= 1.0", "< 4.0", "!= 2.0.0"
-  s.add_dependency "openssl", "~> 3.0", ">= 3.1.2"
+  s.add_dependency "openssl", ">= 3.1.2"
   s.add_dependency "rubyzip", ">= 1.3.0", "< 3.0"
 
   s.add_development_dependency "jekyll-theme-primer", "~> 0.5"


### PR DESCRIPTION
We ran into this in Homebrew's CI (the formulae.brew.sh site uses jekyll-remote-theme). Ruby 4.0 ships the openssl `4.0.0` gem as its default, but the 0.5.0 release caps the openssl dependency at `~> 3.0`. That excludes `4.x` and forces the old openssl `3.x` line, which fails to load on Ruby 4.0, so the gem currently can't be installed on Ruby 4.0 at all.

This drops the upper bound (keeping the `>= 3.1.2` floor from the Ruby 3.4 SSL/CRL fix) so openssl `4.x` is allowed again.

One suggestion: your CI matrix currently only runs Ruby 3.3, which is why this wasn't caught. Adding Ruby 4.0 would help guard against regressions like this.