### PR TITLE
Allow rubyzip 3.x (fix extraction for the 3.0 API change)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,12 @@
 # History
 
+## Unreleased
+
+### Dependencies
+
+- Allow rubyzip 3.x (`>= 1.3.0, < 4.0`) and make archive extraction compatible
+  with rubyzip's 3.0 API change (#112)
+
 ## 0.5.1
 
 ### Fixes

--- a/jekyll-remote-theme.gemspec
+++ b/jekyll-remote-theme.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "jekyll", ">= 3.5", "< 5.0"
   s.add_dependency "jekyll-sass-converter", ">= 1.0", "< 4.0", "!= 2.0.0"
   s.add_dependency "openssl", ">= 3.1.2"
-  s.add_dependency "rubyzip", ">= 1.3.0", "< 3.0"
+  s.add_dependency "rubyzip", ">= 1.3.0", "< 4.0"
 
   s.add_development_dependency "jekyll_test_plugin_malicious", "~> 0.2"
   s.add_development_dependency "jekyll-theme-primer", "~> 0.5"

--- a/lib/jekyll-remote-theme/downloader.rb
+++ b/lib/jekyll-remote-theme/downloader.rb
@@ -97,12 +97,28 @@ module Jekyll
         # File IO is already open, rewind pointer to start of file to read
         zip_file.rewind
 
+        # Extract each entry by hand rather than calling Zip::Entry#extract,
+        # whose signature changed incompatibly in rubyzip 3.0 (the destination
+        # is now resolved relative to a `destination_directory:` keyword,
+        # mangling the absolute paths we pass). Reading each entry's stream and
+        # writing it ourselves behaves identically across rubyzip 1.x–3.x.
         Zip::File.open(zip_file) do |archive|
-          archive.each { |file| file.extract path_without_name_and_ref(file.name) }
+          archive.each { |entry| extract_entry(entry) }
         end
       ensure
         zip_file.close
         zip_file.unlink
+      end
+
+      # Writes a single zip entry to its destination within theme.root.
+      # path_without_name_and_ref sandboxes the destination, guarding against
+      # Zip Slip.
+      def extract_entry(entry)
+        return if entry.name.end_with?("/") # skip directory entries
+
+        dest = path_without_name_and_ref(entry.name)
+        FileUtils.mkdir_p File.dirname(dest)
+        entry.get_input_stream { |input| File.binwrite(dest, input.read) }
       end
 
       # Full URL to codeload zip download endpoint for the given theme


### PR DESCRIPTION
## What

Widens the runtime constraint to `rubyzip >= 1.3.0, < 4.0` (was `< 3.0`) so GitHub Pages sites can resolve **rubyzip 3.x** (latest 3.4.1), and fixes the extraction code that rubyzip 3.0 broke.

## Why it's not a one-line constraint bump

rubyzip 3.0 is a **breaking major**. `Zip::Entry#extract` now resolves its path argument relative to a new `destination_directory:` keyword (default `"."`). The old code passed an *absolute* destination as that argument, so under rubyzip 3.x the path got mangled and **nothing was extracted** — every theme download silently produced an empty theme. (Reproduced: 14/135 specs fail on rubyzip 3.4.1 with the old code.)

## The fix

Extract each entry by reading its stream and writing it ourselves (`get_input_stream` + `File.binwrite`), which behaves identically across **rubyzip 1.x–3.x** — so the widened `< 4.0` range works end-to-end without forcing anyone off rubyzip 2.x. `path_without_name_and_ref` still sandboxes every destination within `theme.root`, guarding against Zip Slip.

## Verification

Full suite (**135 examples, 0 failures**) passes on **both** rubyzip **2.4.1** and **3.4.1**. RuboCop clean.

Supersedes #112 (which only widened the constraint and left the extraction broken — conflicting + failing CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)