### PR TITLE
Add #128 to the 0.5.2 changelog

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,11 @@
 
 ## 0.5.2
 
+### Fixes
+
+- Fix jekyll-github-metadata 2.15.0+ compatibility when loaded as a theme
+  dependency (#128)
+
 ### Dependencies
 
 - Allow rubyzip 3.x (`>= 1.3.0, < 4.0`) and make archive extraction compatible


### PR DESCRIPTION
0.5.2 hasn't been published yet, so #128 (jekyll-github-metadata theme-dependency compatibility fix — a patch-level bug fix) folds into the 0.5.2 release rather than needing a separate 0.5.3. This adds it to `HISTORY.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)